### PR TITLE
Fixed cli `scope` argument when using `Organization` scope

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ locals {
   #common prefix for command is added
   command_prefix = "aws compute-optimizer put-recommendation-preferences"
 
-  scope_parameters = var.scope_name == null ? null : (var.scope_name == "Organization") ? "--scope-name=Organization,value=${var.scope_value}" : (var.scope_name == "AccountId" && length(var.scope_value) == 12) ? "--scope name=AccountId,value=${var.scope_value}" : (var.scope_name == "ResourceArn") ? "--scope name=ResourceArn,value=${var.scope_value} " : ""
+  scope_parameters = var.scope_name == null ? null : (var.scope_name == "Organization") ? "--scope name=Organization,value=${var.scope_value}" : (var.scope_name == "AccountId" && length(var.scope_value) == 12) ? "--scope name=AccountId,value=${var.scope_value}" : (var.scope_name == "ResourceArn") ? "--scope name=ResourceArn,value=${var.scope_value} " : ""
 
   resuorce_type_parameters = var.resource_type == null ? null : "--resource-type ${var.resource_type}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -32,8 +32,8 @@ variable "resource_type" {
   description     = "The target resource type of the recommendation preference to create."
   default         = null
   validation {
-    condition     = var.resource_type == null ? true : (var.resource_type == "Ec2Instance" || var.resource_type == "AutoScalingGroup" || var.resource_type == "EbsVolume" || var.resource_type == "LambdaFunction" || var.resource_type == "NotApplicable")
-    error_message = "Value has to be from the list :[Ec2Instance,AutoScalingGroup,EbsVolume,LambdaFunction,NotApplicable]."
+    condition     = var.resource_type == null ? true : (var.resource_type == "Ec2Instance" || var.resource_type == "AutoScalingGroup" || var.resource_type == "EbsVolume" || var.resource_type == "LambdaFunction" || var.resource_type == "NotApplicable" || var.resource_type == "EcsService" || var.resource_type == "License" || var.resource_type == "RdsDBInstance")
+    error_message = "Value has to be from the list :[Ec2Instance,AutoScalingGroup,EbsVolume,LambdaFunction,NotApplicable,EcsService,License,RdsDBInstance]."
   }
 }
 


### PR DESCRIPTION
*Description of changes:*
- Fixed cli argument issue when using scope name `Organization`
- Added new supported resource types for the compute-optimizer (based on the latest [cli docs](https://docs.aws.amazon.com/cli/latest/reference/compute-optimizer/put-recommendation-preferences.html#options))


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
